### PR TITLE
Added ability to exclude only specific files.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,6 +202,7 @@ optional arguments:
   --pylib                                include python std lib modules
   --pylib-all                            include python all std lib modules (incl. C modules)
   --x FNAME, --exclude FNAME             input files to skip (multiple file names can be provided)
+  --xx FNAME, --exclude-exact FNAME      same as --exclude, except requires the full match. `-xx foo.bar` will exclude foo.bar, but not foo.bar.blob
   --externals                            create list of direct external dependencies
   --reverse                              draw arrows to (instead of from) imported modules
 

--- a/pydeps/cli.py
+++ b/pydeps/cli.py
@@ -121,6 +121,7 @@ def parse_args(argv=()):
     args.add('--pylib-all', action='store_true', help="include python all std lib modules (incl. C modules)")
     args.add('--include-missing', action='store_true', help="include modules that are not installed (or can't be found on sys.path)")
     args.add('-x', '--exclude', default=[], nargs="+", metavar="FNAME", help="input files to skip")
+    args.add('-xx', '--exclude-exact', default=[], nargs="+", metavar="FNAME_EXACT", help="input files to skip (exact match)")
     args.add('--externals', action='store_true', help='create list of direct external dependencies')
     args.add('--reverse', action='store_true', help="draw arrows to (instead of from) imported modules")
 

--- a/pydeps/depgraph.py
+++ b/pydeps/depgraph.py
@@ -221,6 +221,7 @@ class DepGraph(object):
 
         self.sources = {}             # module_name -> Source
         self.skiplist = [re.compile(fnmatch.translate(arg)) for arg in args['exclude']]
+        self.skiplist += [re.compile('^%s$' % fnmatch.translate(arg)) for arg in args['exclude_exact']]
         # depgraf = {name: imports for (name, imports) in depgraf.items()}
 
         for name, imports in list(depgraf.items()):

--- a/pydeps/pydeps.py
+++ b/pydeps/pydeps.py
@@ -68,8 +68,8 @@ def externals(trgt, **kwargs):
        Called for the ``pydeps --externals`` command.
     """
     kw = dict(
-        T='svg', config=None, debug=False, display=None, exclude=[], externals=True,
-        format='svg', max_bacon=2**65, no_config=True, nodot=False,
+        T='svg', config=None, debug=False, display=None, exclude=[], exclude_exact=[],
+        externals=True, format='svg', max_bacon=2**65, no_config=True, nodot=False,
         noise_level=2**65, noshow=True, output=None, pylib=True, pylib_all=True,
         show=False, show_cycles=False, show_deps=False, show_dot=False,
         show_raw_deps=False, verbose=0, include_missing=True,


### PR DESCRIPTION
This is useful when you want to exclude a specific file, e.g. `Package.SubModule.__init__`, but you still want to see `Package.SubModule.SubSubModule`.