### PR TITLE
Add support for display envvars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ This can be overridden with the ``--display PROGRAM`` option, where ``PROGRAM`` 
 executable that can display the image file of the graph.
 
 You can also export the name of such a viewer in either the ``PYDEPS_DISPLAY``
-or ``BROWSER`` environemment variables, which changes the default behaviour
+or ``BROWSER`` environment variable, which changes the default behaviour
 when ``--display`` is not used.
 
 **Feature requests and bug reports:**

--- a/README.rst
+++ b/README.rst
@@ -51,11 +51,15 @@ sure the ``dot`` command is on your path).
 
 **Displaying the graph:**
 
+To display the resulting ``.svg`` or ``.png`` files, ``pydeps`` by default
+calls an appropriate opener for the platform, like ``xdg-open foo.svg``.
 
-To display the resulting `.svg` files, ``pydeps`` by default
-calls ``firefox foo.svg``.  This is can be overridden with
-the ``--display PROGRAM`` option, where ``PROGRAM`` is an
+This can be overridden with the ``--display PROGRAM`` option, where ``PROGRAM`` is an
 executable that can display the image file of the graph.
+
+You can also export the name of such a viewer in either the ``PYDEPS_DISPLAY``
+or ``BROWSER`` environemment variables, which changes the default behaviour
+when ``--display`` is not used.
 
 **Feature requests and bug reports:**
 

--- a/pydeps/dot.py
+++ b/pydeps/dot.py
@@ -88,14 +88,20 @@ def call_graphviz_dot(src, fmt):
 
 def display_svg(kw, fname):  # pragma: nocover
     """Try to display the svg file on this platform.
+
+       Note that this is also used to display PNG files, despite the name.
     """
-    if kw['display'] is None:
+    display = kw['display']
+    if not display:
+        display = os.getenv('PYDEPS_DISPLAY', os.getenv('BROWSER', None))
+
+    if not display:
         cli.verbose("Displaying:", fname)
         if sys.platform == 'win32':
             os.startfile(fname)
         else:
-            opener = "open" if sys.platform == "darwin" else "xdg-open"
-            subprocess.call([opener, fname])
+            display = "open" if sys.platform == "darwin" else "xdg-open"
+            subprocess.check_call([display, fname])
     else:
-        cli.verbose(kw['display'] + " " + fname)
-        os.system(kw['display'] + " " + fname)
+        cli.verbose(display + " " + fname)
+        subprocess.check_call([display, fname])

--- a/pydeps/pydeps.py
+++ b/pydeps/pydeps.py
@@ -46,7 +46,7 @@ def _pydeps(trgt, **kw):
             try:
                 svg = dot.call_graphviz_dot(dotsrc, fmt)
             except OSError as cause:
-                raise RuntimeError("While rendering {!r}: {}".format(output, cause)) from cause
+                raise RuntimeError("While rendering {!r}: {}".format(output, cause))
             if fmt == 'svg':
                 svg = svg.replace(b'</title>', b'</title><style>.edge>path:hover{stroke-width:8}</style>')
 
@@ -55,13 +55,13 @@ def _pydeps(trgt, **kw):
                     cli.verbose("Writing output to:", output)
                     fp.write(svg)
             except OSError as cause:
-                raise RuntimeError("While writing {!r}: {}".format(output, cause)) from cause
+                raise RuntimeError("While writing {!r}: {}".format(output, cause))
 
             if show_svg:
                 try:
                     dot.display_svg(kw, output)
                 except OSError as cause:
-                    raise RuntimeError("While opening {!r}: {}".format(output, cause)) from cause
+                    raise RuntimeError("While opening {!r}: {}".format(output, cause))
 
 
 def depgraph_to_dotsrc(target, dep_graph, **kw):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ coverage==4.5.1
 enum34==1.0.4;		python_version < "3.4"
 stdlib-list>=0.6.0
 
+setuptools<=49.2.0;		python_version < "3"
+
 pytest==3.7.1
 pytest-cov==2.5.1
 Sphinx>=1.7.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ coverage==4.5.1
 enum34==1.0.4;		python_version < "3.4"
 stdlib-list>=0.6.0
 
-setuptools<=49.2.0;		python_version < "3"
+setuptools<45;		python_version < "3"
 
 pytest==3.7.1
 pytest-cov==2.5.1


### PR DESCRIPTION
Checks both the PYDEPS_DISPLAY and BROWSER envvars to change the default image file opener.

Also: Extended OS error handling when calling dot, graphviz, and the viewer