### PR TITLE
enable no_show in .pydeps configuration file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,6 +218,7 @@ An example .pydeps file::
 
     [pydeps]
     max_bacon = 2
+    no_show = True
     verbose = 0
     pylib = False
     exclude =

--- a/pydeps/cli.py
+++ b/pydeps/cli.py
@@ -125,7 +125,7 @@ def parse_args(argv=()):
     args.add('-o', default=None, kind="FNAME:output", dest='output', metavar="file", help="write output to 'file'")
     args.add('-T', default='svg', dest='format', help="output format (svg|png)")
     args.add('--display', kind="FNAME:exe", default=None, help="program to use to display the graph (png or svg file depending on the T parameter)", metavar="PROGRAM")
-    args.add('--noshow', '--no-show', action='store_true', help="don't call external program to display graph")
+    args.add('--noshow', '--no-show', action='store_true', default=False, dest='no_show', help="don't call external program to display graph")
     args.add('--show-deps', action='store_true', help="show output of dependency analysis")
     args.add('--show-raw-deps', action='store_true', help="show output of dependency analysis before removing skips")
     args.add('--show-dot', action='store_true', help="show output of dot conversion")
@@ -156,18 +156,15 @@ def parse_args(argv=()):
         return dict(
             T='svg', config=None, debug=False, display=None, exclude=[], externals=True,
             fname=_args.fname, format='svg', max_bacon=10, no_config=False, nodot=False,
-            noise_level=200, noshow=True, output=None, pylib=False, pylib_all=False,
+            noise_level=200, no_show=True, output=None, pylib=False, pylib_all=False,
             show=False, show_cycles=False, show_deps=False, show_dot=False,
             show_raw_deps=False, verbose=0, include_missing=True, reverse=False,
             start_color=0, find_package=False,
         )
 
-    _args.show = True
-
     if _args.no_output:
-        _args.noshow = True
-    if _args.noshow:
-        _args.show = False
+        _args.no_show = True
+    _args.show = not _args.no_show
     if _args.nodot and _args.show_cycles:
         error("Can't use --nodot and --show-cycles together")  # pragma: nocover
     if _args.nodot:

--- a/pydeps/pydeps.py
+++ b/pydeps/pydeps.py
@@ -86,7 +86,7 @@ def externals(trgt, **kwargs):
     kw = dict(
         T='svg', config=None, debug=False, display=None, exclude=[], exclude_exact=[],
         externals=True, format='svg', max_bacon=2**65, no_config=True, nodot=False,
-        noise_level=2**65, noshow=True, output=None, pylib=True, pylib_all=True,
+        noise_level=2**65, no_show=True, output=None, pylib=True, pylib_all=True,
         show=False, show_cycles=False, show_deps=False, show_dot=False,
         show_raw_deps=False, verbose=0, include_missing=True, start_color=0
     )


### PR DESCRIPTION
I'm not able to set the `--no-show` flag in the `.pydeps` configuration file.

@eqvis comment (https://github.com/thebjorn/pydeps/issues/20#issuecomment-461402900) make me think at some point in history `noshow=1` did work as intended;  but at least in my setup (pydeps v1.9.8 and 025c319) it's not the case.

My path force the use of `no_show` to keep consistency with the working (and presumably more used) `max_bacon`.

## Examples

### show or noshow

With either of:
```ini
[pydeps]
noshow = 1
```
Or:
```ini
[pydeps]
show = 0
```

Pydeps attempts to open the SVG in the console browser (lynx in my case, but that's irrelevant).

```console
$ pydeps checker
[...]/pydeps/pydeps/arguments.py:153: UserWarning: Your .pydeps file contained noshow = 1 which doesn't match any argument
  warnings.warn("Your .pydeps file contained %s = %s which doesn't match any argument" % (key, val))
Namespace(cluster=True, debug=False, debug_mf=0, display=None, exclude=[], exclude_exact=[], externals=False, find_package=False, fname='checker', format='svg', include_missing=False, keep_target_cluster=False, log=None, max_bacon=9223372036854775807, max_cluster_size=0, min_cluster_size=0, no_config=False, no_output=False, nodot=None, noise_level=200, noshow=None, only=[], output=None, pylib=False, pylib_all=False, reverse=True, rmprefix=[], show=True, show_cycles=False, show_deps=False, show_dot=False, show_raw_deps=False, start_color=0, verbose=1, version=False)

Error: no "view" mailcap rules found for type "image/svg+xml"


Exiting via interrupt: 2
```

### no_show

With:
```ini
[pydeps]
no_show = 1
```

I get:
```console
$ pydeps checker
Traceback (most recent call last):
  File "[...]/pydeps", line 33, in <module>
    sys.exit(load_entry_point('pydeps', 'console_scripts', 'pydeps')())
  File "[...]/pydeps/pydeps/pydeps.py", line 125, in pydeps
    _args = args if args else cli.parse_args(sys.argv[1:])
  File "[...]/pydeps/pydeps/cli.py", line 153, in parse_args
    _args = args.parse_args(argv)
  File "[...]/pydeps/pydeps/arguments.py", line 155, in parse_args
    argval = args[key]
  File "[...]/pydeps/pydeps/arguments.py", line 108, in __getitem__
    return getattr(self.ns, key)
AttributeError: 'Namespace' object has no attribute 'no_show'
```