### PR TITLE
Add reminder about missing __init__.py to CLI

### DIFF
--- a/pydeps/cli.py
+++ b/pydeps/cli.py
@@ -20,7 +20,10 @@ def error(*args, **kwargs):  # pragma: nocover
     """Print an error message and exit.
     """
     kwargs['file'] = sys.stderr
+    print("args:", args)
     print("\n\tERROR:", *args, **kwargs)
+    if args and args[0].startswith("[Errno 2] No such file or directory"):
+        print("\t(Did you forget to include an __init__.py?)")
     sys.exit(1)
 
 
@@ -120,7 +123,7 @@ def parse_args(argv=()):
         args.add('fname', kind="FNAME:input", help='filename')
     else:
         args.add('--fname', kind="FNAME:input", help='filename')
-    
+
     args.add('-v', '--verbose', default=0, action='count', help="be more verbose (-vv, -vvv for more verbosity)")
     args.add('-o', default=None, kind="FNAME:output", dest='output', metavar="file", help="write output to 'file'")
     args.add('-T', default='svg', dest='format', help="output format (svg|png)")

--- a/pydeps/cli.py
+++ b/pydeps/cli.py
@@ -20,7 +20,6 @@ def error(*args, **kwargs):  # pragma: nocover
     """Print an error message and exit.
     """
     kwargs['file'] = sys.stderr
-    print("args:", args)
     print("\n\tERROR:", *args, **kwargs)
     if args and args[0].startswith("[Errno 2] No such file or directory"):
         print("\t(Did you forget to include an __init__.py?)")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import logging
 from unittest.mock import patch, call
 
 from pydeps.cli import error

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
+import logging
+from unittest.mock import patch, call
 
+from pydeps.cli import error
 from pydeps.pydeps import pydeps
 from tests.filemaker import create_files
 from tests.simpledeps import simpledeps, empty
@@ -24,3 +27,10 @@ def test_output(tmpdir):
         assert not os.path.exists(outname)
         pydeps(fname='foo', **empty('--noshow', output=outname))
         assert os.path.exists(outname)
+
+@patch('sys.exit')
+@patch('builtins.print')
+def test_error(mocked_print, mocked_sys_exit):
+    """Test that error function prints reminder about missing inits on FileNotFoundErrors."""
+    error("[Errno 2] No such file or directory: 'foo'")
+    mocked_print.assert_called_with("\t(Did you forget to include an __init__.py?)")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,3 +33,5 @@ def test_error(mocked_print, mocked_sys_exit):
     """Test that error function prints reminder about missing inits on FileNotFoundErrors."""
     error("[Errno 2] No such file or directory: 'foo'")
     mocked_print.assert_called_with("\t(Did you forget to include an __init__.py?)")
+    # because error invokes sys.exit(1), have to mock it here, otherwise the test would always fail...
+    mocked_sys_exit.assert_called_with(1)


### PR DESCRIPTION
Currently when pydeps is called on a directory without an `__init__.py`, it simply raises errno2 (file not found).  Therefore, ask the user in this case whether they're missing the init.

This addresses #98.