### PR TITLE
Resolves: Add a CI/CD pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,228 @@
+name: CI/CD Pipeline
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.proj_ver_determiner.outputs.package_version }}
+      package_version_tag: ${{ steps.proj_ver_determiner.outputs.package_version_tag }}
+      latest_github_tag: ${{ steps.proj_ver_determiner.outputs.latest_github_tag }}
+      should_deploy: ${{ steps.proj_ver_determiner.outputs.should_deploy }}
+    strategy:
+      matrix:
+        python-version: [ 2.7, 3.6, 3.7, 3.8, 3.9 ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Tooling setup
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install graphviz
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y graphviz
+
+      - name: Install Python tools
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install flake8 wheel
+
+      # Information setup
+
+      - if: matrix.python-version == '3.9'
+        name: Pipeline data gatherer
+        id: data_gatherer
+        run: |
+          # Get default branch
+          REPO="${{ github.repository }}"
+          DEFAULT_BRANCH=`(curl -X GET https://api.github.com/repos/$REPO) | jq '.default_branch'`
+
+          echo "::set-output name=default_branch::$(echo $DEFAULT_BRANCH)"
+
+      - if: matrix.python-version == '3.9'
+        name: Pipeline conditionals handler
+        id: conditionals_handler
+        run: |
+          DEFAULT_BRANCH="${{ steps.data_gatherer.outputs.default_branch }}"
+          GITHUB_REF="${{ github.ref }}"
+          CURRENT_BRANCH=`echo $GITHUB_REF | sed -e "s/^refs\/heads\///"`
+          GITHUB_EVENT_NAME="${{ github.event_name }}"
+          IS_DEFAULT_BRANCH='false'
+          IS_PUSH='false'
+          IS_PUSH_TO_DEFAULT_BRANCH='false'
+
+          if [ $CURRENT_BRANCH == $DEFAULT_BRANCH ]; then
+            IS_DEFAULT_BRANCH='true'
+          fi
+          if [ $GITHUB_EVENT_NAME == 'push' ]; then
+            IS_PUSH='true'
+          fi
+          if [ $CURRENT_BRANCH == $DEFAULT_BRANCH ] && [ $GITHUB_EVENT_NAME == 'push' ]; then
+            IS_PUSH_TO_DEFAULT_BRANCH='true'
+          fi
+
+          echo "::set-output name=is_default_branch::$(echo $IS_DEFAULT_BRANCH)"
+          echo "::set-output name=is_push::$(echo $IS_PUSH)"
+          echo "::set-output name=is_push_to_default_branch::$(echo $IS_PUSH_TO_DEFAULT_BRANCH)"
+
+      - if: steps.conditionals_handler.outputs.is_push_to_default_branch == 'true' && matrix.python-version == '3.9'
+        name: Project version/deploy determiner
+        id: proj_ver_determiner
+        run: |
+          git fetch --all --tags
+
+          PACKAGE_VERSION=$(cat setup.py \
+            | grep version \
+            | head -1 \
+            | sed "s/[version=\', ]//g")
+          PACKAGE_VERSION_TAG=`echo v$PACKAGE_VERSION | sed -e 's/[[:space:]]//'`
+          LATEST_GITHUB_TAG=`echo $(git tag | sort --version-sort | tail -n1)`
+          SHOULD_DEPLOY="false"
+
+          # download semver compare tool
+          curl https://raw.githubusercontent.com/Ariel-Rodriguez/sh-semversion-2/main/semver2.sh -o semver2.sh
+          chmod +x semver2.sh
+
+          if [ -z "$LATEST_GITHUB_TAG" ]; then
+            SHOULD_DEPLOY="true"
+          else
+            if [ `echo $(./semver2.sh $PACKAGE_VERSION_TAG $LATEST_GITHUB_TAG)` = 1 ]; then
+              SHOULD_DEPLOY="true"
+            fi
+          fi
+
+          echo "::set-output name=package_version::$(echo $PACKAGE_VERSION)"
+          echo "::set-output name=package_version_tag::$(echo $PACKAGE_VERSION_TAG)"
+          echo "::set-output name=latest_github_tag::$(echo $LATEST_GITHUB_TAG)"
+          echo "::set-output name=should_deploy::$(echo $SHOULD_DEPLOY)"
+
+      # Code validations and logs generation
+
+      - name: Create logs directory
+        run: |
+          mkdir -p "Python ${{ matrix.python-version }} - logs"
+
+      - name: Install requirements
+        run: |
+          REQS_FILE="requirements.txt"
+
+          if [ -f $REQS_FILE ]; then
+            pip install -r $REQS_FILE 2>&1 | tee "Python ${{ matrix.python-version }} - logs/requirements.log"
+            exit ${PIPESTATUS[0]} # without this explicit exit code return, even if the previous command fails, the step won't return error because of 'tee'
+          fi
+
+      - name: Upload requirements log as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: requirements-log
+          path: "Python ${{ matrix.python-version }} - logs/requirements.log"
+
+      - name: Lint with flake8
+        run: |
+          flake8 pydeps/** --max-line-length=199 2>&1 | tee "Python ${{ matrix.python-version }} - logs/flake8.log"
+          exit ${PIPESTATUS[0]}
+
+      - name: Upload flake8 log as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: flake8-log
+          path: "Python ${{ matrix.python-version }} - logs/flake8.log"
+
+      - name: Run tests with pytest
+        run: |
+          pytest -vv --cov=pydeps . 2>&1 | tee "Python ${{ matrix.python-version }} - logs/pytest.log"
+          exit ${PIPESTATUS[0]}
+
+      - name: Upload pytest log as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: pytest-log
+          path: "Python ${{ matrix.python-version }} - logs/pytest.log"
+
+      # Package application
+
+      - if: matrix.python-version == '3.9'
+        name: Package application
+        run: |
+          python3 setup.py sdist bdist_wheel
+
+      - if: matrix.python-version == '3.9'
+        name: Upload packages as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Packages
+          path: dist/
+
+  cd:
+    if: needs.ci.outputs.should_deploy == 'true'
+    name: Continuous Deployment
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Tooling setup
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install deployment tools
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install twine
+
+      # Download CI artifacts
+
+      - name: Download and extract package artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: Packages
+          path: dist/
+
+      # Package deployment
+
+      - name: Package deployment
+        run: |
+          twine upload -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} dist/*
+
+      # GitHub deploy
+
+      - name: Push GitHub tag
+        run: |
+          GITHUB_TAG="${{ needs.ci.outputs.package_version_tag }}"
+
+          git config --global user.email ${{ secrets.GH_USER_EMAIL }}
+          git config --global user.name ${{ secrets.GH_USER_NAME }}
+          git tag $GITHUB_TAG
+          git push origin --tags
+
+      - name: Create and publish release
+        run: |
+          PACKAGE_VERSION="${{ needs.ci.outputs.package_version }}"
+          RELEASE_TAG="${{ needs.ci.outputs.package_version_tag }}"
+          PREVIOUS_TAG="${{ needs.ci.outputs.latest_github_tag }}"
+          RELEASE_TITLE="Version $PACKAGE_VERSION"
+          START_LINE=$(( $( grep -n "## $RELEASE_TAG" CHANGELOG.md | grep -Eo '^[^:]+' ) + 2 ))
+          END_LINE=$(( $( grep -n "## $PREVIOUS_TAG" CHANGELOG.md | grep -Eo '^[^:]+' ) - 2 ))
+          RELEASE_NOTES=$(echo "$( sed -n "$START_LINE,$END_LINE"p CHANGELOG.md )")
+          RELEASE_ASSETS="dist/pydeps-$PACKAGE_VERSION-py3-none-any.whl dist/pydeps-$PACKAGE_VERSION.tar.gz" # list the relative paths to the files separated by a single space
+
+          gh release create $RELEASE_TAG \
+          --title "$RELEASE_TITLE" \
+          --notes "$RELEASE_NOTES" \
+          $RELEASE_ASSETS
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,7 +5,7 @@ on: [ push, pull_request, workflow_dispatch ]
 jobs:
   ci:
     name: Continuous Integration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       package_version: ${{ steps.proj_ver_determiner.outputs.package_version }}
       package_version_tag: ${{ steps.proj_ver_determiner.outputs.package_version_tag }}
@@ -30,10 +30,24 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y graphviz
 
-      - name: Install Python tools
+      - name: Install pip for Python ${{ matrix.python-version }}
         run: |
-          python3 -m pip install --upgrade pip
-          pip install flake8 wheel
+          PYTHON_VERSION="${{ matrix.python-version }}"
+
+          if [ $PYTHON_VERSION == '2.7' ]; then
+            curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+            python2 get-pip.py
+            pip2 --version
+          else
+            sudo apt update
+            sudo apt install -y python3-pip
+            pip3 --version
+          fi
+
+      - if: matrix.python-version == '3.9'
+        name: Install Python tools
+        run: |
+          pip3 install flake8 wheel packaging
 
       # Information setup
 
@@ -79,24 +93,14 @@ jobs:
         run: |
           git fetch --all --tags
 
-          PACKAGE_VERSION=$(cat setup.py \
-            | grep version \
-            | head -1 \
-            | sed "s/[version=\', ]//g")
+          PACKAGE_VERSION=$(python3 setup.py --version)
           PACKAGE_VERSION_TAG=`echo v$PACKAGE_VERSION | sed -e 's/[[:space:]]//'`
           LATEST_GITHUB_TAG=`echo $(git tag | sort --version-sort | tail -n1)`
+          IS_NEW_VERSION=$(python3 -c "import sys, packaging.version as v;p=v.parse;s=sys.argv;a=p(s[1]);b=p(s[2]);print((a>b)-(a<b))" $PACKAGE_VERSION_TAG $LATEST_GITHUB_TAG)
           SHOULD_DEPLOY="false"
 
-          # download semver compare tool
-          curl https://raw.githubusercontent.com/Ariel-Rodriguez/sh-semversion-2/main/semver2.sh -o semver2.sh
-          chmod +x semver2.sh
-
-          if [ -z "$LATEST_GITHUB_TAG" ]; then
+          if [ -z "$LATEST_GITHUB_TAG" ] || [ $IS_NEW_VERSION == 1 ]; then
             SHOULD_DEPLOY="true"
-          else
-            if [ `echo $(./semver2.sh $PACKAGE_VERSION_TAG $LATEST_GITHUB_TAG)` = 1 ]; then
-              SHOULD_DEPLOY="true"
-            fi
           fi
 
           echo "::set-output name=package_version::$(echo $PACKAGE_VERSION)"
@@ -110,13 +114,19 @@ jobs:
         run: |
           mkdir -p "Python ${{ matrix.python-version }} - logs"
 
-      - name: Install requirements
+      - name: Install requirements for Python ${{ matrix.python-version }}
         run: |
           REQS_FILE="requirements.txt"
+          PYTHON_VERSION="${{ matrix.python-version }}"
 
           if [ -f $REQS_FILE ]; then
-            pip install -r $REQS_FILE 2>&1 | tee "Python ${{ matrix.python-version }} - logs/requirements.log"
-            exit ${PIPESTATUS[0]} # without this explicit exit code return, even if the previous command fails, the step won't return error because of 'tee'
+            if [ $PYTHON_VERSION == '2.7' ]; then
+              pip2 install -r $REQS_FILE 2>&1 | tee "Python $PYTHON_VERSION - logs/requirements.log"
+              exit ${PIPESTATUS[0]} # without this explicit exit code return, even if the previous command fails, the step won't return error because of 'tee'
+            else
+              pip3 install -r $REQS_FILE 2>&1 | tee "Python $PYTHON_VERSION - logs/requirements.log"
+              exit ${PIPESTATUS[0]}
+            fi
           fi
 
       - name: Upload requirements log as artifact
@@ -128,15 +138,7 @@ jobs:
       - if: matrix.python-version == '3.9'
         name: Lint with flake8
         run: |
-          flake8 pydeps/** --max-line-length=199 2>&1 | tee "Python ${{ matrix.python-version }} - logs/flake8.log"
-          exit ${PIPESTATUS[0]}
-
-      - if: matrix.python-version == '3.9'
-        name: Upload flake8 log as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: Python ${{ matrix.python-version }} - flake8-log
-          path: "Python ${{ matrix.python-version }} - logs/flake8.log"
+          flake8 pydeps/** --max-line-length=199
 
       - name: Run tests with pytest
         run: |
@@ -173,7 +175,7 @@ jobs:
     if: needs.ci.outputs.should_deploy == 'true'
     name: Continuous Deployment
     needs: ci
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -187,8 +189,9 @@ jobs:
 
       - name: Install deployment tools
         run: |
-          python3 -m pip install --upgrade pip
-          pip install twine
+          sudo apt update
+          sudo apt install -y python3-pip
+          pip3 install twine
 
       # Download CI artifacts
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -147,6 +147,12 @@ jobs:
           name: pytest-log
           path: "Python ${{ matrix.python-version }} - logs/pytest.log"
 
+      - name: Upload coverage to codecov.io
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN}}
+          fail_ci_if_error: false
+
       # Package application
 
       - if: matrix.python-version == '3.9'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -122,18 +122,20 @@ jobs:
       - name: Upload requirements log as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: requirements-log
+          name: Python ${{ matrix.python-version }} - requirements-log
           path: "Python ${{ matrix.python-version }} - logs/requirements.log"
 
-      - name: Lint with flake8
+      - if: matrix.python-version == '3.9'
+        name: Lint with flake8
         run: |
           flake8 pydeps/** --max-line-length=199 2>&1 | tee "Python ${{ matrix.python-version }} - logs/flake8.log"
           exit ${PIPESTATUS[0]}
 
-      - name: Upload flake8 log as artifact
+      - if: matrix.python-version == '3.9'
+        name: Upload flake8 log as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: flake8-log
+          name: Python ${{ matrix.python-version }} - flake8-log
           path: "Python ${{ matrix.python-version }} - logs/flake8.log"
 
       - name: Run tests with pytest
@@ -144,7 +146,7 @@ jobs:
       - name: Upload pytest log as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: pytest-log
+          name: Python ${{ matrix.python-version }} - pytest-log
           path: "Python ${{ matrix.python-version }} - logs/pytest.log"
 
       - name: Upload coverage to codecov.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,148 @@
+# Changelog
+
+## v1.9.14
+
+Fixes a cryptic error message when the directory is missing an `__init__.py` file.
+
+## v1.9.13
+
+Keep track with PyPI version.
+
+## v1.9.10
+
+Honor no_show from .pydeps file.
+
+## v1.9.8
+
+See #33.
+
+## v1.9.7
+
+Check ``PYDEPS_DISPLAY`` and ``BROWSER`` for a program to open the graph.
+
+## v1.9.6
+
+``--no-show`` and ``--no-dot`` as aliases for ``--noshow``
+and ``--nodot``
+
+## v1.9.5
+
+Fix for pre-commit hook.
+
+## v1.9.4
+
+Support for https://pre-commit.com/
+
+## v1.9.3
+
+Push typo fix to pypi.
+
+## v1.9.2
+
+Documentation updates.
+
+## v1.9.1
+
+Graphs are now stable across runs for Python 3.x as well as for Python 2.7.
+
+## v1.9.0
+
+Version 1.9.0 supports Python 3.8.
+
+## v1.8.8
+
+
+
+## v1.8.6
+
+Bugfix.
+
+## v1.8.5
+
+Add hover-hightlighted paths.
+
+## v1.8.3
+
+Bugfix release.
+
+## v1.8.2
+
+New flag `--only`.
+
+## v1.8.1
+
+
+
+## v1.8.0
+
+Clusters.
+
+## v1.7.3
+
+Version 1.7.3 includes a new flag ``-xx`` or ``--exclude-exact`` which matches the functionality of the ``--exclude`` flag,
+except it requires an exact match, i.e. ``-xx foo.bar`` will exclude foo.bar, but not ``foo.bar.blob`` (thanks to
+@AvenzaOleg for the PR).
+
+## v1.7.2
+
+Adds support for --no-output flag.
+
+## v1.7.1
+
+Fixes excludes in .pydeps file.
+
+## v1.7.0
+
+
+
+## v1.6.2
+
+Fix for --noshow --show-cycles from PR# 13.
+
+## v1.6.1
+
+Now with images in readme on both github and PyPi (https://stackoverflow.com/questions/51803904/how-do-you-link-to-images-from-your-docs-folder-in-your-readme-rst)
+
+## v1.6.0
+
+This release reworks some of the confusion between file names/paths and module names/paths.
+
+## v1.5.0
+
+Py3 support (thanks @eight04 )
+
+## v1.4.0
+
+
+
+## v1.3.9
+
+
+
+## v1.3.7
+
+
+
+## v1.3.6
+
+
+
+## v1.3.5
+
+
+
+## v1.3.4
+
+
+
+## v1.3.1
+
+
+
+## v1.3.0
+
+
+
+## v1.2.9
+
+


### PR DESCRIPTION
### The pipeline runs:

1. CI
- GitHub tag detemination and generation
- unit tests and flake8 code validations
- upload of test results to Codecov
- process logs and packages generation
- uploading of artifacts to pipeline run (checkout the PR run of the pipeline for artifact download)

2. CD
- deployment to production
- GitHub tag push
- GitHub Release with asset attachment and automated changes inclusion from CHANGELOG.md - [example test release]()

### Setup:

- add a PyPI access token as secret with the name **PYPI_API_TOKEN** (used by twine to upload packages to PyPI)
- add your GitHub user email as secret with the name **GH_USER_EMAIL**
- add your GitHub username as secret with the name **GH_USER_NAME** (GitHub username and email are used for git authentication for tag push)

### File changes:

- add standardized `CHANGELOG.md` (used also for automated inclusion of changes to the GitHub release)
- the format for entering changes for a new version to the changelog is:
  - \#\# new tag i.e. v1.0.0
  - empty line
  - **changes**
  - empty line

### Deployment process:

- the Continuous Deployment job is executed when a push commit to the default branch is made with a higher value to the version attribute in the `setup.py`
- the GitHub release step in the CD job won't execute if there is no entry for the new version in the `CHANGELOG.md` file

Please let us know if anything could be done better and/or if any other automation is required by the project! We would be happy to improve it to satisfactory completion 🙂  

Resolves #108 