### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
+setuptools<45;		python_version < "3"
+
 PyYAML>=3.12
-cov-core==1.15.0
-coverage==5.5
 enum34==1.0.4;		python_version < "3.4"
 stdlib-list>=0.6.0
 
-setuptools<45;		python_version < "3"
+coverage==5.5
+pytest>=4.6
+pytest-cov>=2.12.1
 
-pytest==3.7.1
-pytest-cov==2.5.1
 Sphinx>=1.7.6


### PR DESCRIPTION
This will give coverage==5.5, pytest-cov==2.12.1 on all supported pythons.
Python 2.7 will get pytest 4.6.11 and the rest will get 6.2.5.