### PR TITLE
Enable parsing of extension-less files

### DIFF
--- a/pydeps/dummymodule.py
+++ b/pydeps/dummymodule.py
@@ -16,10 +16,13 @@ def is_module(directory):
 
 
 def is_pysource(fname):
-    """A file name is a python source file iff it ends with '.py' and doesn't
-       start with a dot.
+    """A file name is a python source file iff (it's extensionless or
+       ends with '.py') and doesn't start with a dot.
     """
-    return not fname.startswith('.') and fname.endswith('.py')
+    if not fname.startswith('.'):
+        if len(fname.split('.')) == 1 or fname.endswith('.py'):
+            return True
+    return False
 
 
 def fname2modname(fname, package_root):

--- a/pydeps/target.py
+++ b/pydeps/target.py
@@ -28,7 +28,7 @@ class Target(object):
             sys.exit(1)
         self.is_dir = os.path.isdir(self.path)
         self.is_module = self.is_dir and '__init__.py' in os.listdir(self.path)
-        self.is_pysource = os.path.splitext(self.path)[1] in ('.py', '.pyc', '.pyo')
+        self.is_pysource = os.path.splitext(self.path)[1] in ('.py', '.pyc', '.pyo') or os.path.splitext(self.path)[1] == ''
         self.fname = os.path.basename(self.path)
         if self.is_dir:
             self.dirname = self.fname

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -13,6 +13,13 @@ def test_file():
     with create_files(files) as workdir:
         assert simpledeps('a.py') == set()
 
+def test_file_no_py_extension():
+    files = """
+        a: |
+            import collections
+    """
+    with create_files(files) as workdir:
+        assert simpledeps('a') == set()
 
 def test_file_pylib():
     files = """


### PR DESCRIPTION
It's somewhat common for python scripts to be stored on disk as if they were executables (i.e. with no extension).

However, the current `is_pysource` function and properties explicitly check for a few known python extensions which causing `pydeps` to fail on such scripts (due to a ` assert target.is_pysource` call in `DummyModule`.

This PR proposes adding a condition to assume any extension-less file is in fact a python script. I've added a test case to verify the change.