### PR TITLE
remove 90% of imp usage

### DIFF
--- a/pydeps/mf27.py
+++ b/pydeps/mf27.py
@@ -6,12 +6,13 @@ from modulefinder import (
 )
 import warnings
 with warnings.catch_warnings():
-    warnings.simplefilter('ignore', PendingDeprecationWarning)
+    warnings.simplefilter('ignore', DeprecationWarning)
     import imp
 import marshal
 import dis
 
 HAVE_ARGUMENT = dis.HAVE_ARGUMENT
+PYC_MAGIC_NUMBER = b'\xa7\r\r\n'
 
 # monkey-patch broken modulefinder._find_module
 # (https://github.com/python/cpython/issues/84530)
@@ -38,18 +39,18 @@ class ModuleFinder(NativeModuleFinder):
         # fqname = dotted module name we're loading
         suffix, mode, kind = file_info
         kstr = {
-            imp.PKG_DIRECTORY: 'PKG_DIRECTORY',
-            imp.PY_SOURCE: 'PY_SOURCE',
-            imp.PY_COMPILED: 'PY_COMPILED',
+            modulefinder._PKG_DIRECTORY: 'PKG_DIRECTORY',
+            modulefinder._PY_SOURCE: 'PY_SOURCE',
+            modulefinder._PY_COMPILED: 'PY_COMPILED',
         }.get(kind, 'unknown-kind')
         self.msgin(2, "load_module(%s) fqname=%s, fp=%s, pathname=%s" % (kstr, fqname, fp and "fp", pathname))
 
-        if kind == imp.PKG_DIRECTORY:
+        if kind == modulefinder._PKG_DIRECTORY:
             module = self.load_package(fqname, pathname)
             self.msgout(2, "load_module ->", module)
             return module
 
-        if kind == imp.PY_SOURCE:
+        if kind == modulefinder._PY_SOURCE:
             txt = fp.read()
             txt += b'\n' if isinstance(txt, bytes) else '\n'
             co = compile(
@@ -59,13 +60,13 @@ class ModuleFinder(NativeModuleFinder):
                 dont_inherit=True  # [pydeps] don't inherit future statements from current environment
             )
 
-        elif kind == imp.PY_COMPILED:
-            # a .pyc file is a binary file containing only thee things:
+        elif kind == modulefinder._PY_COMPILED:
+            # a .pyc file is a binary file containing only three things:
             #  1. a four-byte magic number
             #  2. a four byte modification timestamp, and
             #  3. a Marshalled code object
             # from: https://nedbatchelder.com/blog/200804/the_structure_of_pyc_files.html
-            if fp.read(4) != imp.get_magic():
+            if fp.read(4) != PYC_MAGIC_NUMBER:
                 self.msgout(2, "raise ImportError: Bad magic number", pathname)
                 raise ImportError("Bad magic number in %s" % pathname)
             fp.read(4)   # skip modification timestamp

--- a/pydeps/mf27.py
+++ b/pydeps/mf27.py
@@ -4,15 +4,16 @@ import modulefinder
 from modulefinder import (
     ModuleFinder as NativeModuleFinder
 )
+from importlib.util import MAGIC_NUMBER
 import warnings
 with warnings.catch_warnings():
+    warnings.simplefilter('ignore', PendingDeprecationWarning)
     warnings.simplefilter('ignore', DeprecationWarning)
     import imp
 import marshal
 import dis
 
 HAVE_ARGUMENT = dis.HAVE_ARGUMENT
-PYC_MAGIC_NUMBER = b'\xa7\r\r\n'
 
 # monkey-patch broken modulefinder._find_module
 # (https://github.com/python/cpython/issues/84530)
@@ -66,7 +67,7 @@ class ModuleFinder(NativeModuleFinder):
             #  2. a four byte modification timestamp, and
             #  3. a Marshalled code object
             # from: https://nedbatchelder.com/blog/200804/the_structure_of_pyc_files.html
-            if fp.read(4) != PYC_MAGIC_NUMBER:
+            if fp.read(4) != MAGIC_NUMBER:
                 self.msgout(2, "raise ImportError: Bad magic number", pathname)
                 raise ImportError("Bad magic number in %s" % pathname)
             fp.read(4)   # skip modification timestamp

--- a/pydeps/mf27.py
+++ b/pydeps/mf27.py
@@ -15,6 +15,11 @@ import dis
 
 HAVE_ARGUMENT = dis.HAVE_ARGUMENT
 
+# from stdlib's modulefinder
+_PY_SOURCE = 1
+_PY_COMPILED = 2
+_PKG_DIRECTORY = 5
+
 # monkey-patch broken modulefinder._find_module
 # (https://github.com/python/cpython/issues/84530)
 # in Python 3.8-3.10
@@ -40,18 +45,18 @@ class ModuleFinder(NativeModuleFinder):
         # fqname = dotted module name we're loading
         suffix, mode, kind = file_info
         kstr = {
-            modulefinder._PKG_DIRECTORY: 'PKG_DIRECTORY',
-            modulefinder._PY_SOURCE: 'PY_SOURCE',
-            modulefinder._PY_COMPILED: 'PY_COMPILED',
+            _PKG_DIRECTORY: 'PKG_DIRECTORY',
+            _PY_SOURCE: 'PY_SOURCE',
+            _PY_COMPILED: 'PY_COMPILED',
         }.get(kind, 'unknown-kind')
         self.msgin(2, "load_module(%s) fqname=%s, fp=%s, pathname=%s" % (kstr, fqname, fp and "fp", pathname))
 
-        if kind == modulefinder._PKG_DIRECTORY:
+        if kind == _PKG_DIRECTORY:
             module = self.load_package(fqname, pathname)
             self.msgout(2, "load_module ->", module)
             return module
 
-        if kind == modulefinder._PY_SOURCE:
+        if kind == _PY_SOURCE:
             txt = fp.read()
             txt += b'\n' if isinstance(txt, bytes) else '\n'
             co = compile(
@@ -61,7 +66,7 @@ class ModuleFinder(NativeModuleFinder):
                 dont_inherit=True  # [pydeps] don't inherit future statements from current environment
             )
 
-        elif kind == modulefinder._PY_COMPILED:
+        elif kind == _PY_COMPILED:
             # a .pyc file is a binary file containing only three things:
             #  1. a four-byte magic number
             #  2. a four byte modification timestamp, and


### PR DESCRIPTION
Issue #159 

The last use is:

```python
# monkey-patch broken modulefinder._find_module
# (https://github.com/python/cpython/issues/84530)
# in Python 3.8-3.10
if hasattr(modulefinder, '_find_module'):
    modulefinder._find_module = imp.find_module
```

No idea how to fix this without resorting to `imp`.

I've also changed the warnings filter as it seems `imp` throws actual deprecation warnings now (not pending anymore).
Maybe I could duplicate for DeprecationWarning instead of replacing the line. Let me know.

Creating PR to see how tests behave (do you have GHA setup?).