### PR TITLE
stdlib-list only for python < 3.10

### DIFF
--- a/pydeps/pystdlib.py
+++ b/pydeps/pystdlib.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import sys
-import stdlib_list
 import warnings
+
+if sys.version_info[:2] < (3, 10):
+    import stdlib_list
 
 
 def pystdlib():

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools>=65.5.1; python_version >= "3"
 
 PyYAML>=3.12
 enum34==1.0.4;		python_version < "3.4"
-stdlib-list>=0.6.0
+stdlib-list>=0.6.0	python_version < "3.10"
 
 tomlkit>=0.7.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools>=65.5.1; python_version >= "3"
 
 PyYAML>=3.12
 enum34==1.0.4;		python_version < "3.4"
-stdlib-list>=0.6.0	python_version < "3.10"
+stdlib-list>=0.6.0;	python_version < "3.10"
 
 tomlkit>=0.7.0
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['tests*']),
     install_requires=[
         'enum34; python_version < "3.4"',
-        'stdlib_list',
+        'stdlib_list; python_version < "3.10"',
     ],
     long_description=io.open('README.rst', encoding='utf8').read(),
     entry_points={


### PR DESCRIPTION
• modify requirements to import stdlib-list when python version < 3.10
+ conditional import for stdlib-list