### PR TITLE
Drop python<3.6 and simplify dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-setuptools<45                  ; python_version < "3"
-setuptools>=70.0.0             ; python_version >= "3"
+setuptools>=70.0.0
 PyYAML==6.0.1
-enum34==1.0.4                  ; python_version < "3.4"
 stdlib-list>=0.6.0
 tomlkit>=0.7.0
 coverage>=5.5

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setuptools.setup(
     name='pydeps',
     version=version,
     packages=setuptools.find_packages(exclude=['tests*']),
+    python_requires=">=3.6",
     install_requires=[
-        'enum34; python_version < "3.4"',
         'stdlib_list',
     ],
     long_description=io.open('README.rst', encoding='utf8').read(),


### PR DESCRIPTION
I've defensively updated the min. required Python version to 3.6, which is the minimal version stated in the conda-forge recipe. Note that the latest officially supported Python version is currently 3.9, so one could go higher if desired.

This update allows removing special handling of dependencies for older python versions.