### PR TITLE
feat(target): add use_calling_fname kwarg to constructor

### DIFF
--- a/pydeps/dummymodule.py
+++ b/pydeps/dummymodule.py
@@ -16,7 +16,7 @@ def is_module(directory):
 
 
 def is_pysource(fname):
-    """A file name is a python source file iff it ends with '.py(w?)' and 
+    """A file name is a python source file iff it ends with '.py(w?)' and
        doesn't start with a dot.
     """
     return not fname.startswith('.') and fname.endswith(('.py', '.pyw'))
@@ -86,16 +86,16 @@ class DummyModule(object):
             assert target.is_pysource
             cli.verbose(1, "target is a FILE")
             # if working on a single file, we don't need to create a dummy
-            # module, this also avoids problems with file names that are 
+            # module, this also avoids problems with file names that are
             # not importable (e.g. `foo.bar.py)
             # self.fname = target.calling_fname
-            self.fname = target.fname
+            self.fname = target.get_src_fname()
             self.absname = target.package_root
             # with open(self.fname, 'w') as fp:
             #     self.print_import(fp, target.modpath)
 
         log.debug(
-            "dummy-filename: %r (%s)[module=%s, dir=%s, file=%s]", 
+            "dummy-filename: %r (%s)[module=%s, dir=%s, file=%s]",
             self.fname, self.absname, target.is_module, target.is_dir, target.is_pysource
         )
 

--- a/pydeps/target.py
+++ b/pydeps/target.py
@@ -21,13 +21,23 @@ class Target(object):
     is_module = False
     is_dir = False
 
-    def __init__(self, path):
+    def __init__(self, path, **kwargs):
+        """Initialise target
+
+        Args:
+            path: module path
+
+        Keyword Args:
+            use_calling_fname (bool): flag to use the `calling_fname` instead of `fname` in `self.get_src_fname`
+        """
+
         # log.debug("CURDIR: %s, path: %s, exists: %s", os.getcwd(), path, os.path.exists(path))
         # print("Target::CURDIR: %s, path: %s, exists: %s" % (os.getcwd(), path, os.path.exists(path)))
 
         self.calling_fname = path
         self.calling_dir = os.getcwd()
         self.exists = os.path.exists(path)
+        self.use_calling_fname = kwargs.get('use_calling_fname', False)
 
         if self.exists:
             self.path = os.path.realpath(path)
@@ -64,6 +74,12 @@ class Target(object):
             self.syspath_dir,
             self._path_parts(self.relpath)[0]
         )
+
+    def get_src_fname(self):
+        """Return the source file name to use."""
+        log.debug("[get_src_fname] use_calling_name: %s", self.use_calling_fname)
+
+        return self.calling_fname if self.use_calling_fname else self.fname
 
     @contextmanager
     def chdir_work(self):

--- a/tests/test_externals.py
+++ b/tests/test_externals.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import ast
 
-from pydeps.pydeps import pydeps
+from pydeps.pydeps import pydeps, externals
+from pydeps.target import Target
 from tests.filemaker import create_files
 from tests.simpledeps import simpledeps
 
@@ -24,3 +25,30 @@ def test_relative_imports(capsys):
         pydeps(fname='foo', externals=True)
         io = capsys.readouterr()
         assert ast.literal_eval(io.out) == ['bar']
+
+
+def test_externals_with_nested_sourcefile():
+    files = """
+        foo:
+            - __init__.py
+            - a.py: |
+                from bar import b
+        bar:
+            - __init__.py
+            - b.py: |
+                from baz import c
+        baz:
+            - __init__.py
+            - c.py: print('hello world')
+    """
+    with create_files(files):
+        assert simpledeps('foo') == {
+            'bar -> foo.a',
+            'bar.b -> foo.a',
+        }
+        ext = externals(
+            Target('foo/a.py', use_calling_fname=True),
+            pylib_all=False,
+            pylib=False,
+        )
+        assert "bar" in ext


### PR DESCRIPTION
 - useful when calling externals() directly and passing a target class that represents a nested source file.
 - the flag is used in a new get_src_fname() method on the target class, which is called by DummyModule to get text content