### PR TITLE
Improve exclude method of DepGraph

### DIFF
--- a/pydeps/depgraph.py
+++ b/pydeps/depgraph.py
@@ -280,6 +280,8 @@ class DepGraph(object):
 
         #: dict[module_name] -> Source object
         self.sources = {}
+        self._accepted = set()  # cache dla modułów, które nie zostały wykluczone
+        self._rejected = set()  # cache dla modułów, które zostały wykluczone
         self.skiplist = [re.compile(fnmatch.translate(arg)) for arg in args['exclude']]
         self.skiplist += [re.compile('^%s$' % fnmatch.translate(arg)) for arg in args['exclude_exact']]
         # depgraf = {name: imports for (name, imports) in depgraf.items()}
@@ -412,7 +414,22 @@ class DepGraph(object):
         return 4 if res > 4 else res
 
     def _exclude(self, name):
-        return any(skip.match(name) for skip in self.skiplist)
+        # Sprawdzenie cache'a
+        if name in self._accepted:
+            return False
+        if name in self._rejected:
+            return True
+        
+        # Uruchomienie obecnej logiki
+        is_excluded = any(skip.match(name) for skip in self._skiplist)
+        
+        # Dodanie do odpowiedniego zbioru
+        if is_excluded:
+            self._rejected.add(name)
+        else:
+            self._accepted.add(name)
+        
+        return is_excluded
 
     def add_source(self, src):
         if src.name in self.sources:
@@ -548,3 +565,5 @@ class DepGraph(object):
     def _add_skip(self, name):
         # print 'add skip:', name
         self.skiplist.append(re.compile(fnmatch.translate(name)))
+        self._accepted.clear()
+        self._rejected.clear()

--- a/pydeps/depgraph.py
+++ b/pydeps/depgraph.py
@@ -421,7 +421,7 @@ class DepGraph(object):
             return True
         
         # Uruchomienie obecnej logiki
-        is_excluded = any(skip.match(name) for skip in self._skiplist)
+        is_excluded = any(skip.match(name) for skip in self.skiplist)
         
         # Dodanie do odpowiedniego zbioru
         if is_excluded:

--- a/pydeps/depgraph.py
+++ b/pydeps/depgraph.py
@@ -280,8 +280,8 @@ class DepGraph(object):
 
         #: dict[module_name] -> Source object
         self.sources = {}
-        self._accepted = set()  # cache dla modułów, które nie zostały wykluczone
-        self._rejected = set()  # cache dla modułów, które zostały wykluczone
+        self._accepted = set()
+        self._rejected = set()
         self.skiplist = [re.compile(fnmatch.translate(arg)) for arg in args['exclude']]
         self.skiplist += [re.compile('^%s$' % fnmatch.translate(arg)) for arg in args['exclude_exact']]
         # depgraf = {name: imports for (name, imports) in depgraf.items()}

--- a/pydeps/depgraph.py
+++ b/pydeps/depgraph.py
@@ -414,16 +414,16 @@ class DepGraph(object):
         return 4 if res > 4 else res
 
     def _exclude(self, name):
-        # Sprawdzenie cache'a
+        # Check if in cache
         if name in self._accepted:
             return False
         if name in self._rejected:
             return True
         
-        # Uruchomienie obecnej logiki
+        # calculate if match against any pattern - expensive steep
         is_excluded = any(skip.match(name) for skip in self.skiplist)
         
-        # Dodanie do odpowiedniego zbioru
+        # add to cache
         if is_excluded:
             self._rejected.add(name)
         else:


### PR DESCRIPTION
This is to speed up `_exclude` by cache `any(skip.match(name) for skip in self.skiplist)` using sets. 

The alternative is to use `dict[str, bool]` instead of two sets. 

In our case, this speeds up execution from ~150s to ~50s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up exclusion checks by caching results and invalidating the cache when the skip list changes.
> 
> - Introduces `_accepted` and `_rejected` sets in `DepGraph` to memoize `_exclude(name)` results
> - Updates `_exclude` to consult/populate caches instead of re-evaluating all `skiplist` patterns each time
> - Ensures cache correctness by clearing both sets in `_add_skip` whenever new skip patterns are added
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54f52e4797c10de24d559bfcfa362c13f2e3f95b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->