### PR TITLE
setup.py: require Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
     name='pydeps',
     version=version,
     packages=setuptools.find_packages(exclude=['tests*']),
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     install_requires=[
         'stdlib_list',
     ],


### PR DESCRIPTION
The README states only Python 3.10
is supported, so align setup.py
with that.